### PR TITLE
Pin arcade version and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This repository contains a simple scaffolded Arcade project.
 
 ## Setup
 
-Create a virtual environment and install the project requirements:
+Create a virtual environment and install the project requirements.
+The project depends on `arcade>=2.6,<2.7`, so make sure this
+version is installed. If you have previously installed dependencies,
+run the install command again to ensure the correct version of Arcade
+is used:
 
 ```bash
 python -m venv venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-arcade
+arcade>=2.6,<2.7


### PR DESCRIPTION
## Summary
- pin `arcade` dependency to `>=2.6,<2.7`
- document the version requirement in the setup instructions and advise reinstalling deps

## Testing
- `pip install -r requirements.txt` *(fails: no route to host)*